### PR TITLE
ロードマップ15出荷キャンセル　未記入を記入をフラッシュメッセージで返す

### DIFF
--- a/laravel/app/Http/Controllers/ShipmentCancelController.php
+++ b/laravel/app/Http/Controllers/ShipmentCancelController.php
@@ -27,22 +27,21 @@ class ShipmentCancelController extends Controller
 
     public function shipment_cancel_check(Request $request)
     {
-    	$item_code = $request->input('item_code');
+        $item_code = $request->input('item_code');
         $delivery_user_id = $request->input('delivery_user_id');
         $status = $request->input('status');
         $ship_date = $request->input('ship_date');
 
-        $item_ids = [$request->input('item_ids')];
-        $original_item_ids = $request->input('item_ids');
+        $item_ids = $request->input('item_ids');
         $status_edit = $request->input('status_edit');
 
         if (empty($status_edit)) {
         	$stock_indexes = Inventory::editIndex($item_code, $delivery_user_id, $status, $ship_date)->get();
             session()->flash('flash_message', 'どこまで進捗を戻すか？は入力必須です');
-            return view('cancel', compact('stock_indexes', 'item_code', 'delivery_user_id', 'status', 'ship_date', 'item_ids', 'original_item_ids'));
+            return view('cancel', compact('stock_indexes', 'item_code', 'delivery_user_id', 'status', 'ship_date', 'item_ids'));
         }
 
-        if (empty($original_item_ids)) {
+        if (empty($item_ids)) {
         	$stock_indexes = Inventory::editIndex($item_code, $delivery_user_id, $status, $ship_date)->get();
             session()->flash('flash_message', '出荷取消を行う対象を選択して下さい');
             return view('cancel', compact('stock_indexes', 'item_code', 'delivery_user_id', 'status', 'ship_date', 'status_edit'));
@@ -55,7 +54,7 @@ class ShipmentCancelController extends Controller
 
     public function shipment_cancel_execute(Request $request)
     {
-        $item_ids = [$request->input('item_ids')];
+        $item_ids = $request->input('item_ids');
         $status_edit = $request->input('status_edit');
 
         try {   

--- a/laravel/app/Http/Controllers/ShipmentCancelController.php
+++ b/laravel/app/Http/Controllers/ShipmentCancelController.php
@@ -33,16 +33,16 @@ class ShipmentCancelController extends Controller
         $ship_date = $request->input('ship_date');
 
         $item_ids = [$request->input('item_ids')];
-        $item_idsc = $request->input('item_ids');
+        $original_item_ids = $request->input('item_ids');
         $status_edit = $request->input('status_edit');
 
         if (empty($status_edit)) {
         	$stock_indexes = Inventory::editIndex($item_code, $delivery_user_id, $status, $ship_date)->get();
             session()->flash('flash_message', 'どこまで進捗を戻すか？は入力必須です');
-            return view('cancel', compact('stock_indexes', 'item_code', 'delivery_user_id', 'status', 'ship_date', 'item_ids'));
+            return view('cancel', compact('stock_indexes', 'item_code', 'delivery_user_id', 'status', 'ship_date', 'item_ids', 'original_item_ids'));
         }
 
-        if (empty($item_idsc)) {
+        if (empty($original_item_ids)) {
         	$stock_indexes = Inventory::editIndex($item_code, $delivery_user_id, $status, $ship_date)->get();
             session()->flash('flash_message', '出荷取消を行う対象を選択して下さい');
             return view('cancel', compact('stock_indexes', 'item_code', 'delivery_user_id', 'status', 'ship_date', 'status_edit'));

--- a/laravel/app/Http/Controllers/ShipmentCancelController.php
+++ b/laravel/app/Http/Controllers/ShipmentCancelController.php
@@ -32,7 +32,7 @@ class ShipmentCancelController extends Controller
         $status = $request->input('status');
         $ship_date = $request->input('ship_date');
 
-        $item_ids = [$request->input('item_ids')];
+        $item_ids = $request->input('item_ids');
         $status_edit = $request->input('status_edit');
 
         if (empty($status_edit)) {

--- a/laravel/app/Http/Controllers/ShipmentCancelController.php
+++ b/laravel/app/Http/Controllers/ShipmentCancelController.php
@@ -27,14 +27,27 @@ class ShipmentCancelController extends Controller
 
     public function shipment_cancel_check(Request $request)
     {
+    	$item_code = $request->input('item_code');
+        $delivery_user_id = $request->input('delivery_user_id');
+        $status = $request->input('status');
+        $ship_date = $request->input('ship_date');
+
         $item_ids = [$request->input('item_ids')];
         $status_edit = $request->input('status_edit');
-        $stock_indexes = Inventory::editCheck($item_ids)->get();
 
         if (empty($status_edit)) {
+        	$stock_indexes = Inventory::editIndex($item_code, $delivery_user_id, $status, $ship_date)->get();
             session()->flash('flash_message', 'どこまで進捗を戻すか？は入力必須です');
-            return redirect('/shipment/cancels');
+            return view('cancel', compact('stock_indexes', 'item_code', 'delivery_user_id', 'status', 'ship_date', 'item_ids'));
         }
+
+        if (empty($item_ids)) {
+        	$stock_indexes = Inventory::editIndex($item_code, $delivery_user_id, $status, $ship_date)->get();
+            session()->flash('flash_message', '出荷取消を行う対象を選択して下さい');
+            return view('cancel', compact('stock_indexes', 'item_code', 'delivery_user_id', 'status', 'ship_date', 'status_edit'));
+        }
+
+        $stock_indexes = Inventory::editCheck($item_ids)->get();
 
         return view('cancel_check', compact('stock_indexes', 'item_ids', 'status_edit'));
     } 

--- a/laravel/app/Http/Controllers/ShipmentCancelController.php
+++ b/laravel/app/Http/Controllers/ShipmentCancelController.php
@@ -32,7 +32,8 @@ class ShipmentCancelController extends Controller
         $status = $request->input('status');
         $ship_date = $request->input('ship_date');
 
-        $item_ids = $request->input('item_ids');
+        $item_ids = [$request->input('item_ids')];
+        $item_idsc = $request->input('item_ids');
         $status_edit = $request->input('status_edit');
 
         if (empty($status_edit)) {
@@ -41,7 +42,7 @@ class ShipmentCancelController extends Controller
             return view('cancel', compact('stock_indexes', 'item_code', 'delivery_user_id', 'status', 'ship_date', 'item_ids'));
         }
 
-        if (empty($item_ids)) {
+        if (empty($item_idsc)) {
         	$stock_indexes = Inventory::editIndex($item_code, $delivery_user_id, $status, $ship_date)->get();
             session()->flash('flash_message', '出荷取消を行う対象を選択して下さい');
             return view('cancel', compact('stock_indexes', 'item_code', 'delivery_user_id', 'status', 'ship_date', 'status_edit'));
@@ -49,7 +50,7 @@ class ShipmentCancelController extends Controller
 
         $stock_indexes = Inventory::editCheck($item_ids)->get();
 
-        return view('cancel_check', compact('stock_indexes', 'item_ids', 'status_edit'));
+        return view('cancel_check', compact('stock_indexes', 'item_ids', 'status', 'status_edit'));
     } 
 
     public function shipment_cancel_execute(Request $request)

--- a/laravel/app/Http/Controllers/StockController.php
+++ b/laravel/app/Http/Controllers/StockController.php
@@ -36,53 +36,6 @@ class StockController extends Controller
         return view('order', compact('order_indexes', 'item_code', 'delivery_user_id', 'order_start', 'order_end'));
     }
 
-    public function edit(Request $request)
-    {
-        $item_code = $request->input('item_code');
-        $delivery_user_id = $request->input('delivery_user_id');
-        $status = $request->input('status');
-        $ship_date = $request->input('ship_date');
-
-        if (isset($item_code) or ($delivery_user_id) or ($status) or ($ship_date)) {
-
-            $stock_indexes = Inventory::editIndex($item_code, $delivery_user_id, $status, $ship_date)->get();
-
-        return view('edit', compact('stock_indexes', 'item_code', 'delivery_user_id', 'status', 'ship_date'));
-        }
-
-        return view('edit');
-    }
-
-    public function edit_check(Request $request)
-    {
-        $item_ids = [$request->input('item_ids')];
-        $status_edit = $request->input('status_edit');
-        $stock_indexes = Inventory::editCheck($item_ids)->get();
-
-        if (empty($status_edit)) {
-            session()->flash('flash_message', 'どこまで進捗を戻すか？は入力必須です');
-            return redirect('edits');
-        }
-
-        return view('edit_check', compact('stock_indexes', 'item_ids', 'status_edit'));
-    } 
-
-    public function edit_go(Request $request)
-    {
-        $item_ids = [$request->input('item_ids')];
-        $status_edit = $request->input('status_edit');
-
-        try {   
-            Inventory::inventoryEdit($item_ids, $status_edit);
-        } catch (\Exception $e) {
-            report($e);
-            session()->flash('flash_message', '注文データの取消を中断しました');
-            return redirect('edits');
-        }
-        session()->flash('flash_message', '出荷指示の取消を実行しました。必ず輸送会社へ連絡をして下さい');
-        return redirect('edits');
-    } 
-
     public function temporary(Request $request)
     {
         $item_code = $request->input('item_code');

--- a/laravel/app/Models/Inventory.php
+++ b/laravel/app/Models/Inventory.php
@@ -19,7 +19,7 @@ class Inventory extends Model
         'status'
         ];
 
-    public function scopeStockIndex($query, $item_code, $delivery_user_id, $status, $ship_date)
+    public function scopeStockIndex($query, $item_code, $delivery_user_id, $status)
     {
         $query->join('orders', 'inventories.item_code', '=', 'orders.item_code');
 
@@ -29,10 +29,6 @@ class Inventory extends Model
 
         if (isset($delivery_user_id)) {
             $query->where('orders.delivery_user_id', $delivery_user_id);
-        }
-
-        if (isset($ship_date)) {
-            $query->where('inventories.ship_date', $ship_date);
         }
 
         if (isset($status)) {
@@ -101,14 +97,17 @@ class Inventory extends Model
             ->join('items', 'inventories.item_code', '=', 'items.item_code')
             ->join('client_companies', 'orders.end_user_id', 'client_companies.id');
 
-        $ship_arranged = \Config::get('const.Temporaries.ship_arranged');
-        $shipped = \Config::get('const.Temporaries.shipped');
-
-        $query->where('inventories.status', $ship_arranged)
-            ->orwhere('inventories.status', $shipped);
-
         if (isset($status)) {
             $query->where('inventories.status', $status);
+
+        } else {
+            $ship_arranged = \Config::get('const.Temporaries.ship_arranged');
+            $shipped = \Config::get('const.Temporaries.shipped');
+
+            $query->where (function($query) use ($ship_arranged, $shipped) {
+                $query->where('inventories.status', $ship_arranged)
+                    ->orwhere('inventories.status', $shipped);
+            });
         }
 
         if (isset($item_code)) {
@@ -149,7 +148,7 @@ class Inventory extends Model
         return $query;
     }
 
-    public function scopeinventoryEdit($query, $item_ids, $status_edit) 
+    public function scopeInventoryEdit($query, $item_ids, $status_edit) 
     {
         foreach ($item_ids as $item_id) {
 

--- a/laravel/app/Models/Inventory.php
+++ b/laravel/app/Models/Inventory.php
@@ -136,9 +136,9 @@ class Inventory extends Model
             ->join('client_companies', 'orders.end_user_id', 'client_companies.id');
 
         if (isset($item_ids)) {
-            foreach ($item_ids as $item_id) {
-                $query->whereIn('inventories.id', $item_id);
-            }
+            
+            $query->whereIn('inventories.id', $item_ids);
+            
         }
 
         $query->oldest('charge_code');
@@ -150,10 +150,7 @@ class Inventory extends Model
 
     public function scopeInventoryEdit($query, $item_ids, $status_edit) 
     {
-        foreach ($item_ids as $item_id) {
-
-            $query->whereIn('id', $item_id)->update(['status' => $status_edit]);
-        }
+        $query->whereIn('id', $item_ids)->update(['status' => $status_edit]);
 
         return $query;
     }

--- a/laravel/app/Models/Inventory.php
+++ b/laravel/app/Models/Inventory.php
@@ -19,7 +19,7 @@ class Inventory extends Model
         'status'
         ];
 
-    public function scopeStockIndex($query, $item_code, $delivery_user_id, $status)
+    public function scopeStockIndex($query, $item_code, $delivery_user_id, $status, $ship_date)
     {
         $query->join('orders', 'inventories.item_code', '=', 'orders.item_code');
 
@@ -30,6 +30,11 @@ class Inventory extends Model
         if (isset($delivery_user_id)) {
             $query->where('orders.delivery_user_id', $delivery_user_id);
         }
+
+        if (isset($ship_date)) {
+            $query->where('inventories.ship_date', $ship_date);
+        }
+
         if (isset($status)) {
             $query->where('inventories.status', $status);
         }

--- a/laravel/database/seeds/InventoriesTableSeeder.php
+++ b/laravel/database/seeds/InventoriesTableSeeder.php
@@ -11,6 +11,6 @@ class InventoriesTableSeeder extends Seeder
      */
     public function run()
     {
-		factory('App\Models\Inventory', 500)->create();
+		factory('App\Models\Inventory', 20)->create();
     }
 }

--- a/laravel/resources/views/cancel.blade.php
+++ b/laravel/resources/views/cancel.blade.php
@@ -18,7 +18,7 @@
                 <input type="text" name="delivery_user_id" value="{{ $delivery_user_id ?? null }}">
             </label></p>
             <p><label for="order_date">表示する納入日を選んで下さい。
-                <p>納入日<input type="date" name="ship_date"></p>
+                <p>納入日<input type="date" name="ship_date" value="{{ $ship_date ?? null }}"></p>
             </label></p>
             <p>進捗進捗状態を選んで下さい。
               <label for="status">
@@ -70,7 +70,7 @@
             @foreach ($stock_indexes as $stock)
             <tr>
               <td>
-                <input class="form-check-input" type="checkbox" id="{{$stock->id}}" name="item_ids[]" value="{{$stock->id}}">
+                <input class="form-check-input" type="checkbox" id="{{$stock->id}}" name="item_ids[]" value="{{$stock->id}}" <?php $stock->id === (int)old("item_ids") ? "checked" : '' ?>>
                 <label class="form-check-label" for="checkbox">{{$stock->id}}</label>
               </td>
                 <td>{{$stock->item_code}}</td>
@@ -96,6 +96,9 @@
             </tr>
             @endforeach
         </table>
+            <input type="text" name="item_code" value="{{ $item_code ?? null }}" readonly>
+            <input type="text" name="delivery_user_id" value="{{ $delivery_user_id ?? null }}" readonly>
+            <input type="date" name="ship_date" value="{{ $ship_date ?? null }}" readonly>
       </form>
          
         @else

--- a/laravel/resources/views/cancel.blade.php
+++ b/laravel/resources/views/cancel.blade.php
@@ -70,7 +70,7 @@
             @foreach ($stock_indexes as $stock)
             <tr>
               <td>
-                <input class="form-check-input" type="checkbox" id="{{$stock->id}}" name="item_ids[]" value="{{$stock->id}}" <?php if (isset($original_item_ids)) { $key = in_array($stock->id, $original_item_ids); if ($key) {echo "checked"; }} ?>>
+                <input class="form-check-input" type="checkbox" id="{{$stock->id}}" name="item_ids[]" value="{{$stock->id}}" <?php if (isset($item_ids)) { $key = in_array($stock->id, $item_ids); if ($key) {echo "checked"; }} ?>>
                 <label class="form-check-label" for="checkbox">{{$stock->id}}</label>
               </td>
                 <td>{{$stock->item_code}}</td>

--- a/laravel/resources/views/cancel.blade.php
+++ b/laravel/resources/views/cancel.blade.php
@@ -1,7 +1,7 @@
 @extends('common')
 
 @section('content')
-@include('header')  
+@include('header')
     <div class="main">
       @if (session('flash_message'))
           <div class="flash_message">
@@ -70,7 +70,7 @@
             @foreach ($stock_indexes as $stock)
             <tr>
               <td>
-                <input class="form-check-input" type="checkbox" id="{{$stock->id}}" name="item_ids[]" value="{{$stock->id}}" <?php $stock->id === (int)old("item_ids") ? "checked" : '' ?>>
+                <input class="form-check-input" type="checkbox" id="{{$stock->id}}" name="item_ids[]" value="{{$stock->id}}" <?php if (isset($item_ids)) { $key = in_array($stock->id, $item_ids); if ($key) {"checked"; }} ?>>
                 <label class="form-check-label" for="checkbox">{{$stock->id}}</label>
               </td>
                 <td>{{$stock->item_code}}</td>

--- a/laravel/resources/views/cancel.blade.php
+++ b/laravel/resources/views/cancel.blade.php
@@ -70,7 +70,7 @@
             @foreach ($stock_indexes as $stock)
             <tr>
               <td>
-                <input class="form-check-input" type="checkbox" id="{{$stock->id}}" name="item_ids[]" value="{{$stock->id}}" <?php if (isset($item_ids)) { $key = in_array($stock->id, $item_ids); if ($key) {echo "checked"; }} ?>>
+                <input class="form-check-input" type="checkbox" id="{{$stock->id}}" name="item_ids[]" value="{{$stock->id}}" <?php if (isset($original_item_ids)) { $key = in_array($stock->id, $original_item_ids); if ($key) {echo "checked"; }} ?>>
                 <label class="form-check-label" for="checkbox">{{$stock->id}}</label>
               </td>
                 <td>{{$stock->item_code}}</td>

--- a/laravel/resources/views/cancel.blade.php
+++ b/laravel/resources/views/cancel.blade.php
@@ -70,7 +70,7 @@
             @foreach ($stock_indexes as $stock)
             <tr>
               <td>
-                <input class="form-check-input" type="checkbox" id="{{$stock->id}}" name="item_ids[]" value="{{$stock->id}}" <?php if (isset($item_ids)) { $key = in_array($stock->id, $item_ids); if ($key) {"checked"; }} ?>>
+                <input class="form-check-input" type="checkbox" id="{{$stock->id}}" name="item_ids[]" value="{{$stock->id}}" <?php if (isset($item_ids)) { $key = in_array($stock->id, $item_ids); if ($key) {echo "checked"; }} ?>>
                 <label class="form-check-label" for="checkbox">{{$stock->id}}</label>
               </td>
                 <td>{{$stock->item_code}}</td>
@@ -99,6 +99,7 @@
             <input type="text" name="item_code" value="{{ $item_code ?? null }}" readonly>
             <input type="text" name="delivery_user_id" value="{{ $delivery_user_id ?? null }}" readonly>
             <input type="date" name="ship_date" value="{{ $ship_date ?? null }}" readonly>
+            <input type="text" name="status" value="{{ $status ?? null }}" readonly>
       </form>
          
         @else

--- a/laravel/resources/views/cancel_check.blade.php
+++ b/laravel/resources/views/cancel_check.blade.php
@@ -14,7 +14,7 @@
         @if(!empty($stock_indexes))
         <form action="{{url('/shipment/cancels')}}" method="POST" name="status_edit" value="{{ $status_edit ?? null }}">
             @csrf
-          <p>どこまで戻すか　<input class="check_date" name="status_edit" value="{{ $status_edit ?? null }}" readonly>
+          <p>現在の進捗　<input class="check_date" name="status" value="{{ $status ?? null }}" readonly>   どこまで戻すか　<input class="check_date" name="status_edit" value="{{ $status_edit ?? null }}" readonly>
           <P>出荷取消手配　確定　<input type="submit" value="出荷取消"></P>        
         <table border="1">
             <tr>


### PR DESCRIPTION
出荷指示強制取消の画面にて、下記の情報がnullの場合に再選択を促す動作を実装したい
・どこまで進捗を戻すか選ぶラジオボタン　（変数名　$status_edit）
・どのIDが対象か　（配列　$item_ids)
